### PR TITLE
Add installation of the Azure CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,32 @@
 FROM jetbrains/teamcity-agent
 
+USER root
+
+# Update apt
+RUN apt-get update
+
+# Install curl and sudo
+RUN apt-get install -y curl sudo
+
 # Install node LTS
-RUN apt-get update && \
-  apt-get install curl sudo -y && \
-  curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
   apt-get install -y nodejs build-essential && \
-  npm install npm@latest -g
+  npm install -g npm@latest
 
 # Install Ruby
-RUN apt-get install ruby-full -y
+RUN apt-get install -y ruby-full
 
-# Install aws cli
+# Install AWS cli
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
   python get-pip.py && \
   pip install awscli --upgrade --user
+
+# Install Azure cli
+RUN apt-get install -y ca-certificates apt-transport-https lsb-release gnupg && \
+  curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
+  echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/azure-cli.list && \
+  apt-get update && \
+  apt-get install -y azure-cli
 
 ENV PATH=/root/.local/bin:$PATH
 
@@ -23,5 +36,7 @@ RUN apt-get install -y apt-transport-https && \
   echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list && \
   apt-get update && \
   apt-get install -y kubectl
+
+USER buildagent
 
 CMD "/run-services.sh"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a Docker image for TeamCity build agents which comes with Node.js LTS (1
 
 It is used the same way as the official image from JetBrains, but also supports some configuration for AWS cli and Kubernetes.
 
-When the TeamCity agent and server runs in the same Kubernetes cluster it is able to pick up the kubernetes config automatically, and you do not need to mount the .kube/config.
+When the TeamCity agent and server run in the same Kubernetes cluster it is able to pick up the kubernetes config automatically, and you do not need to mount the .kube/config.
 
 ```
 docker run -ti --privileged \


### PR DESCRIPTION
Add installation of the Azure CLI, aka `az`, for the purpose of building docker images and pushing them to the Azure container registry.

No consideration has been made to support the execution of this TeamCity agent within a k8s cluster on Azure.